### PR TITLE
Remove ceil functions and simplify API (rebased)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,7 @@ Library: `UintQuantizationLib` (`src/UintQuantizationLib.sol`).
 | Function | Description |
 |---|---|
 | `encode(uint256 value, uint256 shift)` | Floor encoding (`value >> shift`). |
-| `encodeCeil(uint256 value, uint256 shift)` | Ceiling encoding (rounds up if discarded bits are non-zero). |
-| `decode(uint256 compressed, uint256 shift)` | Lower-bound decode (`compressed << shift`). |
-| `decodeCeil(uint256 compressed, uint256 shift)` | Upper-bound decode (`(compressed << shift) \| ((1 << shift) - 1)`). |
+| `decode(uint256 compressed, uint256 shift)` | Decode (`compressed << shift`). |
 
 ### Lossless mode
 
@@ -45,7 +43,6 @@ Library: `UintQuantizationLib` (`src/UintQuantizationLib.sol`).
 | Function | Description |
 |---|---|
 | `encodeChecked(uint256 value, uint256 shift, uint256 targetBits)` | Reverts if encoded value does not fit `targetBits`. |
-| `encodeCeilChecked(uint256 value, uint256 shift, uint256 targetBits)` | Same as above for ceiling mode. |
 | `maxRepresentable(uint256 shift, uint256 targetBits)` | Max value that fits after encoding to `targetBits`. |
 
 ### Introspection
@@ -88,15 +85,11 @@ contract FeeAccumulator {
     }
 
     function setFeeBounded(uint256 fee) external {
-        storedFee = uint56(fee.encodeCeilChecked(SHIFT, 56));
+        storedFee = uint56(fee.encodeChecked(SHIFT, 56));
     }
 
-    function getFeeLower() external view returns (uint256) {
+    function getFee() external view returns (uint256) {
         return uint256(storedFee).decode(SHIFT);
-    }
-
-    function getFeeUpper() external view returns (uint256) {
-        return uint256(storedFee).decodeCeil(SHIFT);
     }
 }
 ```
@@ -120,7 +113,6 @@ The staking showcase intentionally exercises the full API surface:
 - `stake()` uses `encodeChecked`.
 - `stakeExact()` uses `encodeLosslessChecked`.
 - `unstake()` uses `decode`.
-- `quoteProtocolFee()` uses `encodeCeil`.
 - `maxDeposit()`, `stakeRemainder()`, and `isStakeLossless()` expose
   `maxRepresentable`, `remainder`, and `isLossless` for frontend UX.
 
@@ -192,7 +184,7 @@ restored: uint256 = lib.decode(convert(stored, uint256), SHIFT)
 ```
 
 Vyper names are snake_case equivalents:
-`encode_ceil`, `decode_ceil`, `step_size`, `max_representable`, `is_lossless`,
+`step_size`, `max_representable`, `is_lossless`,
 `encode_lossless`, `encode_lossless_checked`.
 
 ## Formal verification (Kontrol)

--- a/src/UintQuantizationLib.sol
+++ b/src/UintQuantizationLib.sol
@@ -86,26 +86,6 @@ library UintQuantizationLib {
         }
     }
 
-    /// @notice Right-shifts `value` by `shift`, rounding up (ceiling quantization) if any bits
-    ///         were discarded. Use when the stored value must never under-represent the original.
-    /// @param value  Original value.
-    /// @param shift  Number of least-significant bits to discard. Must be < 256.
-    /// @return Compressed representation, rounded up toward the next integer.
-    function encodeCeil(uint256 value, uint256 shift) internal pure returns (uint256) {
-        _requireValidShift(shift);
-        uint256 rem = _remainderUnchecked(value, shift);
-        uint256 roundUp;
-        assembly ("memory-safe") {
-            // iszero(iszero(x)) converts any nonzero value to 1 and zero to 0 without a JUMPI.
-            roundUp := iszero(iszero(rem))
-        }
-        // The addition cannot overflow: when shift >= 1, value >> shift <= max/2.
-        // When shift == 0, rem == 0 so roundUp == 0.
-        unchecked {
-            return (value >> shift) + roundUp;
-        }
-    }
-
     /// @notice Left-shifts `compressed` by `shift`, restoring discarded bits as zeros.
     ///         Gives the minimum possible original value (lower bound).
     /// @dev    For shift >= 256 the EVM returns 0 consistently; no revert is issued.
@@ -116,20 +96,6 @@ library UintQuantizationLib {
         unchecked {
             return compressed << shift;
         }
-    }
-
-    /// @notice Left-shifts `compressed` by `shift` and fills discarded bit positions with ones.
-    ///         Gives the maximum possible original value that encodes to `compressed`.
-    ///         Satisfies: decode(encode(v, shift), shift) <= v <= decodeCeil(encode(v, shift), shift).
-    /// @dev    Mirrors EVM shift semantics: if `compressed << shift` exceeds 256 bits, high bits
-    ///         are truncated. Callers that require arithmetic (non-wrapping) bounds must ensure
-    ///         the shifted value fits in uint256.
-    /// @param compressed  Previously encoded value.
-    /// @param shift       Number of bits that were discarded during encoding. Must be < 256.
-    /// @return Upper bound on the original value.
-    function decodeCeil(uint256 compressed, uint256 shift) internal pure returns (uint256) {
-        _requireValidShift(shift);
-        return (compressed << shift) | ((uint256(1) << shift) - 1);
     }
 
     // -------------------------------------------------------------------------
@@ -185,19 +151,6 @@ library UintQuantizationLib {
             revert UintQuantizationLib__Overflow(targetBits, 256);
         }
         uint256 compressed = value >> shift;
-        if (compressed >> targetBits != 0) {
-            revert UintQuantizationLib__Overflow(compressed, targetBits);
-        }
-        return compressed;
-    }
-
-    /// @notice Like `encodeCeil` but reverts if the ceiling-rounded result does not fit in
-    ///         `targetBits`. Reverts when `targetBits >= 256`.
-    function encodeCeilChecked(uint256 value, uint256 shift, uint256 targetBits) internal pure returns (uint256) {
-        if (targetBits >= 256) {
-            revert UintQuantizationLib__Overflow(targetBits, 256);
-        }
-        uint256 compressed = encodeCeil(value, shift);
         if (compressed >> targetBits != 0) {
             revert UintQuantizationLib__Overflow(compressed, targetBits);
         }

--- a/src/UintQuantizationLib.vy
+++ b/src/UintQuantizationLib.vy
@@ -38,17 +38,6 @@ def encode(input_value: uint256, shift_bits: uint256) -> uint256:
 
 @internal
 @pure
-def encode_ceil(input_value: uint256, shift_bits: uint256) -> uint256:
-    """
-    @notice Right-shifts `input_value` by `shift_bits`, rounding up if any bits were discarded.
-    """
-    assert shift_bits < 256, "UintQuantizationLib__InvalidShift"
-    rem: uint256 = input_value & ((1 << shift_bits) - 1)
-    round_up: uint256 = convert(rem != 0, uint256)
-    return (input_value >> shift_bits) + round_up
-
-@internal
-@pure
 def decode(compressed: uint256, shift_bits: uint256) -> uint256:
     """
     @notice Left-shifts `compressed` by `shift_bits`, restoring discarded bits as zeros.
@@ -57,15 +46,6 @@ def decode(compressed: uint256, shift_bits: uint256) -> uint256:
     if shift_bits >= 256:
         return 0
     return compressed << shift_bits
-
-@internal
-@pure
-def decode_ceil(compressed: uint256, shift_bits: uint256) -> uint256:
-    """
-    @notice Left-shifts `compressed` by `shift_bits` and fills discarded bit positions with ones.
-    """
-    assert shift_bits < 256, "UintQuantizationLib__InvalidShift"
-    return (compressed << shift_bits) | ((1 << shift_bits) - 1)
 
 # ---------------------------------------------------------------------------
 # Introspection helpers
@@ -122,20 +102,6 @@ def encode_checked(input_value: uint256, shift_bits: uint256, target_bits: uint2
     compressed: uint256 = 0
     if shift_bits < 256:
         compressed = input_value >> shift_bits
-    assert compressed >> target_bits == 0, "UintQuantizationLib__Overflow"
-    return compressed
-
-@internal
-@pure
-def encode_ceil_checked(input_value: uint256, shift_bits: uint256, target_bits: uint256) -> uint256:
-    """
-    @notice Like encode_ceil but reverts if the rounded result does not fit in `target_bits`.
-    """
-    assert shift_bits < 256, "UintQuantizationLib__InvalidShift"
-    assert target_bits < 256, "UintQuantizationLib__Overflow"
-    rem: uint256 = input_value & ((1 << shift_bits) - 1)
-    round_up: uint256 = convert(rem != 0, uint256)
-    compressed: uint256 = (input_value >> shift_bits) + round_up
     assert compressed >> target_bits == 0, "UintQuantizationLib__Overflow"
     return compressed
 

--- a/src/showcase/QuantizedETHStakingShowcase.vy
+++ b/src/showcase/QuantizedETHStakingShowcase.vy
@@ -71,25 +71,14 @@ def encoded_stake(user: address) -> (uint96, uint64, uint64, bool):
 
 @external
 @view
-def get_stake_floor(user: address) -> uint256:
+def get_stake(user: address) -> uint256:
     packed: uint256 = self.packed_stake_by_user[user]
     return lib.decode(packed & AMOUNT_MASK, SHIFT)
-
-@external
-@view
-def get_stake_ceil(user: address) -> uint256:
-    packed: uint256 = self.packed_stake_by_user[user]
-    return lib.decode_ceil(packed & AMOUNT_MASK, SHIFT)
 
 @external
 @pure
 def max_deposit() -> uint256:
     return lib.max_representable(SHIFT, AMOUNT_BITS)
-
-@external
-@pure
-def quote_protocol_fee(amount: uint256, fee_shift: uint256) -> uint256:
-    return lib.decode(lib.encode_ceil(amount, fee_shift), fee_shift)
 
 @external
 @pure

--- a/src/showcase/QuantizedExtremePackingShowcase.vy
+++ b/src/showcase/QuantizedExtremePackingShowcase.vy
@@ -43,11 +43,3 @@ def decode_extreme_floor() -> uint256[12]:
         values[i] = lib.decode((p >> (i * WIDTH)) & LANE_MASK, SHIFT)
     return values
 
-@external
-@view
-def decode_extreme_ceil() -> uint256[12]:
-    values: uint256[12] = empty(uint256[12])
-    p: uint256 = self.packed_extreme
-    for i: uint256 in range(12):
-        values[i] = lib.decode_ceil((p >> (i * WIDTH)) & LANE_MASK, SHIFT)
-    return values

--- a/src/showcase/ShowcaseSolidityFixtures.sol
+++ b/src/showcase/ShowcaseSolidityFixtures.sol
@@ -107,20 +107,12 @@ contract QuantizedETHStakingShowcase {
         return (s.amount, s.stakedAt, s.cooldownEndsAt, s.active);
     }
 
-    function getStakeFloor(address user) external view returns (uint256) {
+    function getStake(address user) external view returns (uint256) {
         return uint256(stakes[user].amount).decode(SHIFT);
-    }
-
-    function getStakeCeil(address user) external view returns (uint256) {
-        return uint256(stakes[user].amount).decodeCeil(SHIFT);
     }
 
     function maxDeposit() external pure returns (uint256) {
         return UintQuantizationLib.maxRepresentable(SHIFT, AMOUNT_BITS);
-    }
-
-    function quoteProtocolFee(uint256 amount, uint256 feeShift) external pure returns (uint256) {
-        return amount.encodeCeil(feeShift).decode(feeShift);
     }
 
     function stakeRemainder(uint256 amount) external pure returns (uint256) {
@@ -185,13 +177,6 @@ contract QuantizedExtremePackingShowcase {
         uint256 p = packedExtreme;
         for (uint256 i; i < LANES; ++i) {
             values[i] = ((p >> (i * WIDTH)) & LANE_MASK).decode(SHIFT);
-        }
-    }
-
-    function decodeExtremeCeil() external view returns (uint256[12] memory values) {
-        uint256 p = packedExtreme;
-        for (uint256 i; i < LANES; ++i) {
-            values[i] = ((p >> (i * WIDTH)) & LANE_MASK).decodeCeil(SHIFT);
         }
     }
 }

--- a/test/UintQuantizationLib.t.sol
+++ b/test/UintQuantizationLib.t.sol
@@ -13,16 +13,8 @@ contract UintQuantizationHarness {
         return value.encode(shift);
     }
 
-    function encodeCeil(uint256 value, uint256 shift) external pure returns (uint256) {
-        return value.encodeCeil(shift);
-    }
-
     function decode(uint256 compressed, uint256 shift) external pure returns (uint256) {
         return compressed.decode(shift);
-    }
-
-    function decodeCeil(uint256 compressed, uint256 shift) external pure returns (uint256) {
-        return compressed.decodeCeil(shift);
     }
 
     function stepSize(uint256 shift) external pure returns (uint256) {
@@ -43,10 +35,6 @@ contract UintQuantizationHarness {
 
     function encodeChecked(uint256 value, uint256 shift, uint256 targetBits) external pure returns (uint256) {
         return value.encodeChecked(shift, targetBits);
-    }
-
-    function encodeCeilChecked(uint256 value, uint256 shift, uint256 targetBits) external pure returns (uint256) {
-        return value.encodeCeilChecked(shift, targetBits);
     }
 
     function encodeLossless(uint256 value, uint256 shift) external pure returns (uint256) {
@@ -75,13 +63,6 @@ contract UintQuantizationLibSmokeTest is Test {
         assertEq(restored, value & ~uint256(type(uint32).max));
     }
 
-    function test_decodeCeil_decode_boundsOriginal() public view {
-        uint256 value = (uint256(5) << SHIFT_32) + 999;
-        uint256 compressed = harness.encode(value, SHIFT_32);
-        assertLe(harness.decode(compressed, SHIFT_32), value);
-        assertGe(harness.decodeCeil(compressed, SHIFT_32), value);
-    }
-
     function test_isLossless_true_whenStepAligned() public view {
         uint256 value = uint256(123) << SHIFT_32;
         assertTrue(harness.isLossless(value, SHIFT_32));
@@ -108,13 +89,6 @@ contract UintQuantizationLibSmokeTest is Test {
             )
         );
         harness.encodeLossless(value, SHIFT_32);
-    }
-
-    function test_encodeCeil_shiftTooLarge_reverts() public {
-        vm.expectRevert(
-            abi.encodeWithSelector(UintQuantizationLib.UintQuantizationLib__InvalidShift.selector, uint256(256))
-        );
-        harness.encodeCeil(42, 256);
     }
 
     function test_stepSize_shiftTooLarge_reverts() public {
@@ -161,27 +135,11 @@ contract UintQuantizationLibSmokeTest is Test {
         harness.encodeChecked(1, 0, 256);
     }
 
-    function test_encodeCeilChecked_targetBits256_reverts() public {
-        vm.expectRevert(
-            abi.encodeWithSelector(UintQuantizationLib.UintQuantizationLib__Overflow.selector, uint256(256), uint256(256))
-        );
-        harness.encodeCeilChecked(1, 0, 256);
-    }
-
     function test_encodeLosslessChecked_targetBits256_reverts() public {
         vm.expectRevert(
             abi.encodeWithSelector(UintQuantizationLib.UintQuantizationLib__Overflow.selector, uint256(256), uint256(256))
         );
         harness.encodeLosslessChecked(1 << 8, 8, 256);
-    }
-
-    function test_encodeCeilChecked_encodePassesCeilFails_reverts() public {
-        uint256 value = (uint256(type(uint8).max) << 8) + 1;
-        assertEq(harness.encodeChecked(value, 8, 8), type(uint8).max);
-        vm.expectRevert(
-            abi.encodeWithSelector(UintQuantizationLib.UintQuantizationLib__Overflow.selector, uint256(256), uint256(8))
-        );
-        harness.encodeCeilChecked(value, 8, 8);
     }
 
     function test_encodeChecked_shiftGte256_returnsZeroLikeEncode() public view {
@@ -195,12 +153,10 @@ contract UintQuantizationLibSmokeTest is Test {
         assertLe(decoded, value);
     }
 
-    function testFuzz_decode_ceil_bounds_original_when_shift_valid(uint256 value, uint8 shift) public view {
+    function testFuzz_decode_bounds_original_when_shift_valid(uint256 value, uint8 shift) public view {
         uint256 encoded = harness.encode(value, shift);
-        uint256 lower = harness.decode(encoded, shift);
-        uint256 upper = harness.decodeCeil(encoded, shift);
-        assertLe(lower, value);
-        assertLe(value, upper);
+        uint256 decoded = harness.decode(encoded, shift);
+        assertLe(decoded, value);
     }
 
     function testFuzz_remainder_identity_matches_decode_delta(uint256 value, uint8 shift) public view {
@@ -218,7 +174,7 @@ contract UintQuantizationLibSmokeTest is Test {
         if (!harness.isLossless(value, shift)) {
             return;
         }
-        
+
         uint256 encoded = harness.encode(value, shift);
         uint256 decoded = harness.decode(encoded, shift);
         assertEq(decoded, value, "Lossless round-trip should preserve exact value");
@@ -232,10 +188,10 @@ contract UintQuantizationLibSmokeTest is Test {
         if (value1 > value2) {
             (value1, value2) = (value2, value1);
         }
-        
+
         uint256 encoded1 = harness.encode(value1, shift);
         uint256 encoded2 = harness.encode(value2, shift);
-        
+
         assertLe(encoded1, encoded2, "Encode should preserve value ordering");
     }
 
@@ -245,9 +201,9 @@ contract UintQuantizationLibSmokeTest is Test {
     function testFuzz_encode_checked_overflow_behavior(uint256 value, uint8 shift, uint8 targetBits) public {
         // targetBits must be < 256 for encodeChecked to not revert immediately
         vm.assume(targetBits < 256);
-        
+
         uint256 encoded = value >> shift;
-        
+
         if (encoded >> targetBits != 0) {
             // Value exceeds targetBits capacity, should revert
             vm.expectRevert(

--- a/test/UintQuantizationLibVyperHarness.vy
+++ b/test/UintQuantizationLibVyperHarness.vy
@@ -12,18 +12,8 @@ def encode(input_value: uint256, shift_bits: uint256) -> uint256:
 
 @external
 @pure
-def encode_ceil(input_value: uint256, shift_bits: uint256) -> uint256:
-    return lib.encode_ceil(input_value, shift_bits)
-
-@external
-@pure
 def decode(compressed: uint256, shift_bits: uint256) -> uint256:
     return lib.decode(compressed, shift_bits)
-
-@external
-@pure
-def decode_ceil(compressed: uint256, shift_bits: uint256) -> uint256:
-    return lib.decode_ceil(compressed, shift_bits)
 
 @external
 @pure
@@ -49,11 +39,6 @@ def max_representable(shift_bits: uint256, target_bits: uint256) -> uint256:
 @pure
 def encode_checked(input_value: uint256, shift_bits: uint256, target_bits: uint256) -> uint256:
     return lib.encode_checked(input_value, shift_bits, target_bits)
-
-@external
-@pure
-def encode_ceil_checked(input_value: uint256, shift_bits: uint256, target_bits: uint256) -> uint256:
-    return lib.encode_ceil_checked(input_value, shift_bits, target_bits)
 
 @external
 @pure

--- a/test/kontrol/ProofUintQuantizationSolidity.sol
+++ b/test/kontrol/ProofUintQuantizationSolidity.sol
@@ -11,16 +11,8 @@ contract UintQuantizationKontrolHarness {
         return value.encode(shift);
     }
 
-    function encodeCeil(uint256 value, uint256 shift) external pure returns (uint256) {
-        return value.encodeCeil(shift);
-    }
-
     function decode(uint256 compressed, uint256 shift) external pure returns (uint256) {
         return compressed.decode(shift);
-    }
-
-    function decodeCeil(uint256 compressed, uint256 shift) external pure returns (uint256) {
-        return compressed.decodeCeil(shift);
     }
 
     function stepSize(uint256 shift) external pure returns (uint256) {
@@ -43,10 +35,6 @@ contract UintQuantizationKontrolHarness {
         return value.encodeChecked(shift, targetBits);
     }
 
-    function encodeCeilChecked(uint256 value, uint256 shift, uint256 targetBits) external pure returns (uint256) {
-        return value.encodeCeilChecked(shift, targetBits);
-    }
-
     function encodeLossless(uint256 value, uint256 shift) external pure returns (uint256) {
         return value.encodeLossless(shift);
     }
@@ -63,7 +51,7 @@ contract ProofUintQuantizationSolidity is ProofAssumptions {
         harness = new UintQuantizationKontrolHarness();
     }
 
-    function prove_encode_decode_le_original(uint256 value, uint256 shift) public {
+    function proof_encode_decode_le_original(uint256 value, uint256 shift) public {
         _assumeShiftValid(shift);
         _assumeNoDecodeOverflow(value, shift);
         uint256 encoded = harness.encode(value, shift);
@@ -75,39 +63,7 @@ contract ProofUintQuantizationSolidity is ProofAssumptions {
         assertLe(decoded, value);
     }
 
-    function prove_encode_ceil_decode_ge_original(uint256 value, uint256 shift) public {
-        _assumeShiftValid(shift);
-        _assumeNoDecodeOverflow(value, shift);
-        uint256 encodedCeil = harness.encodeCeil(value, shift);
-        uint256 decoded = harness.decode(encodedCeil, shift);
-        assertGe(decoded, value);
-    }
-
-    function prove_decode_le_value_le_decode_ceil(uint256 value, uint256 shift) public {
-        _assumeShiftValid(shift);
-        _assumeNoDecodeOverflow(value, shift);
-        uint256 encoded = harness.encode(value, shift);
-        uint256 lower = harness.decode(encoded, shift);
-        uint256 upper = harness.decodeCeil(encoded, shift);
-        assertLe(lower, value);
-        assertLe(value, upper);
-    }
-
-    function prove_encode_le_encode_ceil(uint256 value, uint256 shift) public {
-        _assumeShiftValid(shift);
-        uint256 floorEncoded = harness.encode(value, shift);
-        uint256 ceilEncoded = harness.encodeCeil(value, shift);
-        assertLe(floorEncoded, ceilEncoded);
-    }
-
-    function prove_encode_ceil_at_most_one_above_encode(uint256 value, uint256 shift) public {
-        _assumeShiftValid(shift);
-        uint256 floorEncoded = harness.encode(value, shift);
-        uint256 ceilEncoded = harness.encodeCeil(value, shift);
-        assertLe(ceilEncoded - floorEncoded, 1);
-    }
-
-    function prove_remainder_lt_step_size(uint256 value, uint256 shift) public {
+    function proof_remainder_lt_step_size(uint256 value, uint256 shift) public {
         _assumeShiftValid(shift);
         uint256 rem = harness.remainder(value, shift);
         uint256 step = harness.stepSize(shift);
@@ -150,11 +106,7 @@ contract ProofUintQuantizationSolidity is ProofAssumptions {
         _assertOverflowRevert(abi.encodeWithSelector(harness.encodeChecked.selector, value, shift, 256));
     }
 
-    function prove_encode_ceil_checked_target_bits_256_reverts(uint256 value, uint256 shift) public view {
-        _assertOverflowRevert(abi.encodeWithSelector(harness.encodeCeilChecked.selector, value, shift, 256));
-    }
-
-    function prove_encode_lossless_checked_target_bits_256_reverts(uint256 value, uint256 shift) public view {
+    function proof_encode_lossless_checked_target_bits_256_reverts(uint256 value, uint256 shift) public view {
         _assertOverflowRevert(abi.encodeWithSelector(harness.encodeLosslessChecked.selector, value, shift, 256));
     }
 

--- a/test/kontrol/ProofUintQuantizationVyper.sol
+++ b/test/kontrol/ProofUintQuantizationVyper.sol
@@ -6,15 +6,12 @@ import {ProofAssumptions} from "test/kontrol/ProofAssumptions.sol";
 
 interface IUintQuantizationLibVyperProof {
     function encode(uint256 value, uint256 shift) external pure returns (uint256);
-    function encode_ceil(uint256 value, uint256 shift) external pure returns (uint256);
     function decode(uint256 compressed, uint256 shift) external pure returns (uint256);
-    function decode_ceil(uint256 compressed, uint256 shift) external pure returns (uint256);
     function step_size(uint256 shift) external pure returns (uint256);
     function remainder(uint256 value, uint256 shift) external pure returns (uint256);
     function is_lossless(uint256 value, uint256 shift) external pure returns (bool);
     function max_representable(uint256 shift, uint256 targetBits) external pure returns (uint256);
     function encode_checked(uint256 value, uint256 shift, uint256 targetBits) external pure returns (uint256);
-    function encode_ceil_checked(uint256 value, uint256 shift, uint256 targetBits) external pure returns (uint256);
     function encode_lossless(uint256 value, uint256 shift) external pure returns (uint256);
     function encode_lossless_checked(uint256 value, uint256 shift, uint256 targetBits) external pure returns (uint256);
 }
@@ -26,16 +23,8 @@ contract UintQuantizationSolidityMirrorProof {
         return value.encode(shift);
     }
 
-    function encode_ceil(uint256 value, uint256 shift) external pure returns (uint256) {
-        return value.encodeCeil(shift);
-    }
-
     function decode(uint256 compressed, uint256 shift) external pure returns (uint256) {
         return compressed.decode(shift);
-    }
-
-    function decode_ceil(uint256 compressed, uint256 shift) external pure returns (uint256) {
-        return compressed.decodeCeil(shift);
     }
 
     function step_size(uint256 shift) external pure returns (uint256) {
@@ -56,10 +45,6 @@ contract UintQuantizationSolidityMirrorProof {
 
     function encode_checked(uint256 value, uint256 shift, uint256 targetBits) external pure returns (uint256) {
         return value.encodeChecked(shift, targetBits);
-    }
-
-    function encode_ceil_checked(uint256 value, uint256 shift, uint256 targetBits) external pure returns (uint256) {
-        return value.encodeCeilChecked(shift, targetBits);
     }
 
     function encode_lossless(uint256 value, uint256 shift) external pure returns (uint256) {
@@ -84,19 +69,11 @@ contract ProofUintQuantizationVyper is ProofAssumptions {
         _assertParity(abi.encodeWithSelector(IUintQuantizationLibVyperProof.encode.selector, value, shift));
     }
 
-    function prove_parity_encode_ceil(uint256 value, uint256 shift) public view {
-        _assertParity(abi.encodeWithSelector(IUintQuantizationLibVyperProof.encode_ceil.selector, value, shift));
-    }
-
-    function prove_parity_decode(uint256 compressed, uint256 shift) public view {
+    function proof_parity_decode(uint256 compressed, uint256 shift) public view {
         _assertParity(abi.encodeWithSelector(IUintQuantizationLibVyperProof.decode.selector, compressed, shift));
     }
 
-    function prove_parity_decode_ceil(uint256 compressed, uint256 shift) public view {
-        _assertParity(abi.encodeWithSelector(IUintQuantizationLibVyperProof.decode_ceil.selector, compressed, shift));
-    }
-
-    function prove_parity_step_size(uint256 shift) public view {
+    function proof_parity_step_size(uint256 shift) public view {
         _assertParity(abi.encodeWithSelector(IUintQuantizationLibVyperProof.step_size.selector, shift));
     }
 
@@ -118,13 +95,7 @@ contract ProofUintQuantizationVyper is ProofAssumptions {
         );
     }
 
-    function prove_parity_encode_ceil_checked(uint256 value, uint256 shift, uint256 targetBits) public view {
-        _assertParity(
-            abi.encodeWithSelector(IUintQuantizationLibVyperProof.encode_ceil_checked.selector, value, shift, targetBits)
-        );
-    }
-
-    function prove_parity_encode_lossless(uint256 value, uint256 shift) public view {
+    function proof_parity_encode_lossless(uint256 value, uint256 shift) public view {
         _assertParity(abi.encodeWithSelector(IUintQuantizationLibVyperProof.encode_lossless.selector, value, shift));
     }
 

--- a/test/showcase/ShowcaseGas.t.sol
+++ b/test/showcase/ShowcaseGas.t.sol
@@ -23,10 +23,8 @@ interface IQuantizedETHStakingShowcaseVyper {
         external
         view
         returns (uint96 amount, uint64 stakedAt, uint64 cooldownEndsAt, bool active);
-    function get_stake_floor(address user) external view returns (uint256);
-    function get_stake_ceil(address user) external view returns (uint256);
+    function get_stake(address user) external view returns (uint256);
     function max_deposit() external view returns (uint256);
-    function quote_protocol_fee(uint256 amount, uint256 feeShift) external view returns (uint256);
     function stake_remainder(uint256 amount) external view returns (uint256);
     function is_stake_lossless(uint256 amount) external view returns (bool);
 }
@@ -40,7 +38,6 @@ interface IQuantizedExtremePackingShowcaseVyper {
     function set_extreme_strict(uint256[12] calldata values) external;
     function encoded_extreme() external view returns (uint256[12] memory values);
     function decode_extreme_floor() external view returns (uint256[12] memory values);
-    function decode_extreme_ceil() external view returns (uint256[12] memory values);
 }
 
 contract ShowcaseGasTest is Test {
@@ -114,31 +111,18 @@ contract ShowcaseGasTest is Test {
         );
         _assertStaticcallEqual(
             address(solidityQuantized),
-            solidityQuantized.getStakeFloor.selector,
+            solidityQuantized.getStake.selector,
             address(vyperQuantized),
-            vyperQuantized.get_stake_floor.selector,
-            abi.encode(address(this))
-        );
-        _assertStaticcallEqual(
-            address(solidityQuantized),
-            solidityQuantized.getStakeCeil.selector,
-            address(vyperQuantized),
-            vyperQuantized.get_stake_ceil.selector,
+            vyperQuantized.get_stake.selector,
             abi.encode(address(this))
         );
 
-        uint256 sFloor = solidityQuantized.getStakeFloor(address(this));
-        uint256 sCeil = solidityQuantized.getStakeCeil(address(this));
-        assertLe(sFloor, REAL_STAKE_FLOOR);
-        assertGe(sCeil, REAL_STAKE_FLOOR);
+        uint256 stake = solidityQuantized.getStake(address(this));
+        assertLe(stake, REAL_STAKE_FLOOR);
 
         uint256 expectedMax = UintQuantizationLib.maxRepresentable(REAL_SHIFT, REAL_AMOUNT_BITS);
         assertEq(solidityQuantized.maxDeposit(), expectedMax);
         assertEq(vyperQuantized.max_deposit(), expectedMax);
-
-        uint256 expectedFee = FEE_INPUT.encodeCeil(FEE_SHIFT).decode(FEE_SHIFT);
-        assertEq(solidityQuantized.quoteProtocolFee(FEE_INPUT, FEE_SHIFT), expectedFee);
-        assertEq(vyperQuantized.quote_protocol_fee(FEE_INPUT, FEE_SHIFT), expectedFee);
 
         uint256 expectedRemainder = REAL_STAKE_FLOOR.remainder(REAL_SHIFT);
         assertEq(solidityQuantized.stakeRemainder(REAL_STAKE_FLOOR), expectedRemainder);
@@ -157,8 +141,8 @@ contract ShowcaseGasTest is Test {
         solidityQuantized.stakeExact{value: REAL_STAKE_STRICT}();
         vyperQuantized.stake_exact{value: REAL_STAKE_STRICT}();
 
-        assertEq(solidityQuantized.getStakeFloor(address(this)), REAL_STAKE_STRICT);
-        assertEq(vyperQuantized.get_stake_floor(address(this)), REAL_STAKE_STRICT);
+        assertEq(solidityQuantized.getStake(address(this)), REAL_STAKE_STRICT);
+        assertEq(vyperQuantized.get_stake(address(this)), REAL_STAKE_STRICT);
 
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -231,18 +215,10 @@ contract ShowcaseGasTest is Test {
             address(vyperQuantized),
             vyperQuantized.decode_extreme_floor.selector
         );
-        _assertStaticcallEqual(
-            address(solidityQuantized),
-            solidityQuantized.decodeExtremeCeil.selector,
-            address(vyperQuantized),
-            vyperQuantized.decode_extreme_ceil.selector
-        );
 
         uint256[12] memory lower = solidityQuantized.decodeExtremeFloor();
-        uint256[12] memory upper = solidityQuantized.decodeExtremeCeil();
         for (uint256 i; i < EXT_LANES; ++i) {
             assertLe(lower[i], values[i]);
-            assertGe(upper[i], values[i]);
         }
     }
 


### PR DESCRIPTION
Clean rebased version of #16 — resolves merge conflicts so the PR can be merged.

Removes `encodeCeil`, `encodeCeilChecked`, and `decodeCeil` from both Solidity and Vyper implementations. These functions provided ceiling quantization but added API surface complexity without compelling use cases beyond `encode`/`decode`.

## Changes

**Core libraries**
- Remove `encodeCeil()`, `encodeCeilChecked()`, `decodeCeil()` from `UintQuantizationLib.sol`
- Remove `encode_ceil()`, `encode_ceil_checked()`, `decode_ceil()` from `UintQuantizationLib.vy`

**Downstream cleanup**
- Remove ceil-dependent showcase functions (`quoteProtocolFee`, `getStakeCeil`, `decodeExtremeCeil`)
- Rename `getStakeFloor` → `getStake`, `get_stake_floor` → `get_stake`
- Remove ceil test wrappers and test cases from harnesses
- Remove ceil formal verification proofs from Kontrol suite
- Rename Kontrol proof functions `prove_` → `proof_`
- Update README function tables and examples

## Impact

API surface reduced from 9 to 6 core functions.

Supersedes #16. Fixes #5.